### PR TITLE
fix: disable Gradle module metadata on JitPack to fix transitive dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+import org.gradle.api.publish.tasks.GenerateModuleMetadata
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlinx.publisher.apache2
@@ -62,6 +63,16 @@ subprojects {
 
     // only configured if subProject applies the publishing plugin
     plugins.withId("org.jetbrains.kotlin.libs.publisher") {
+        // JitPack rewrites Gradle module metadata component identity to com.github.cmdjulian:kirc for all
+        // submodules, breaking transitive dependency resolution. Disable module metadata on JitPack so consumers
+        // fall back to POM files which JitPack handles correctly.
+        if (System.getenv("JITPACK") == "true") {
+            logger.lifecycle("JitPack build detected: disabling Gradle module metadata generation for ${project.name}")
+            tasks.withType<GenerateModuleMetadata>().configureEach {
+                enabled = false
+            }
+        }
+
         publishing {
             repositories {
                 maven {


### PR DESCRIPTION
## Summary

- JitPack rewrites the Gradle module metadata (`.module` files) `component` identity to `com.github.cmdjulian:kirc` for **all** submodules, making them appear as the same component to Gradle consumers
- This breaks transitive `api` dependency resolution — e.g., consumers of `blocking` don't get `image` and `core` transitively despite them being declared as `api` dependencies
- Fix: conditionally disable `.module` file generation when `JITPACK=true` (set automatically by JitPack), so consumers fall back to POM files which have correct coordinates and `compile` scope

## Details

The root cause was confirmed by fetching the published `.module` files from JitPack — every submodule (`blocking`, `image`, `core`, `suspending`) had the same component identity:

```json
"component": {
    "group": "com.github.cmdjulian",
    "module": "kirc"
}
```

The POM files are unaffected and correctly declare transitive deps with `<scope>compile</scope>` for `api` dependencies.

The fix is scoped to JitPack only (`System.getenv("JITPACK") == "true"`), so publishing to Maven Central or GitHub Packages continues to include full Gradle module metadata.